### PR TITLE
Bug fixes to support actual use.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun STHS34PF80 Arduino Library
-version=1.0.0
+version=1.0.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the STMicroelectronics infrared sensor STHS34PF80.

--- a/src/SparkFun_STHS34PF80_Arduino_Library.cpp
+++ b/src/SparkFun_STHS34PF80_Arduino_Library.cpp
@@ -1,6 +1,12 @@
+
+
+
+
 #include "SparkFun_STHS34PF80_Arduino_Library.h"
 
-int32_t STHS34PF80_I2C::begin(uint8_t devAddr, TwoWire& wirePort)
+
+
+bool STHS34PF80_I2C::begin(uint8_t devAddr, TwoWire& wirePort)
 {
     bus.init(devAddr, Wire);
     sensor.read_reg = STHS34PF80_I2C::read;
@@ -8,9 +14,9 @@ int32_t STHS34PF80_I2C::begin(uint8_t devAddr, TwoWire& wirePort)
     sensor.mdelay = STHS34PF80_I2C::delayMS;
     sensor.handle = &bus;
 
-    STHS34PF80::begin();
+    // call super class begin -- it returns 0 on no error
+    return STHS34PF80::begin() == 0;
 
-    return 0; // returns error code here
 }
 
 int32_t STHS34PF80_I2C::read(void* bus, uint8_t addr, uint8_t* data, uint16_t numData)
@@ -32,7 +38,7 @@ void STHS34PF80_I2C::delayMS(uint32_t millisec)
     delay(millisec);
 }
 
-int32_t STHS34PF80_SPI::begin(uint8_t chipSelect, SPIClass &spiPort)
+bool STHS34PF80_SPI::begin(uint8_t chipSelect, SPIClass &spiPort)
 {
     bus.init(chipSelect, spiPort, false);
     sensor.read_reg = STHS34PF80_SPI::read;
@@ -40,9 +46,9 @@ int32_t STHS34PF80_SPI::begin(uint8_t chipSelect, SPIClass &spiPort)
     sensor.mdelay = STHS34PF80_SPI::delayMS;
     sensor.handle = &bus;
 
-    STHS34PF80::begin();
+    // call super class begin -- it returns 0 on no error
+    return STHS34PF80::begin() == 0;
 
-    return 0; // returns error code here
 }
 
 int32_t STHS34PF80_SPI::read(void* bus, uint8_t addr, uint8_t* data, uint16_t numData)

--- a/src/SparkFun_STHS34PF80_Arduino_Library.h
+++ b/src/SparkFun_STHS34PF80_Arduino_Library.h
@@ -19,7 +19,7 @@ Distributed as-is; no warranty is given.
 
 
 #include "sths34pf80_class.h"
-#include "SFE_Bus.h"
+#include "sfe_bus.h"
 #include <Arduino.h>
 #include <Wire.h>
 #include <SPI.h>
@@ -28,7 +28,7 @@ Distributed as-is; no warranty is given.
 class STHS34PF80_I2C : public STHS34PF80
 {
     public: 
-        int32_t begin(uint8_t devAddr = STHS34PF80_I2C_ADD >> 1, TwoWire& wirePort = Wire);
+        bool begin(uint8_t devAddr = STHS34PF80_I2C_ADDRESS, TwoWire& wirePort = Wire);
         static int32_t read(void *, uint8_t, uint8_t *, uint16_t);
         static int32_t write(void *, uint8_t, const uint8_t *, uint16_t);
         static void delayMS(uint32_t millisec);
@@ -39,7 +39,7 @@ class STHS34PF80_I2C : public STHS34PF80
 class STHS34PF80_SPI : public STHS34PF80
 {
     public: 
-        int32_t begin(uint8_t chipSelect, SPIClass &spiPort=SPI);
+        bool begin(uint8_t chipSelect, SPIClass &spiPort=SPI);
         static int32_t read(void *, uint8_t, uint8_t *, uint16_t);
         static int32_t write(void *, uint8_t, const uint8_t *, uint16_t);
         static void delayMS(uint32_t millisec);

--- a/src/sths34pf80_class.h
+++ b/src/sths34pf80_class.h
@@ -4,6 +4,11 @@
 #include "sths34pf80_api/sths34pf80_reg.h"
 #include "sfe_bus.h"
 
+
+// define a standard i2c address (7 bit) macro
+
+#define STHS34PF80_I2C_ADDRESS (STHS34PF80_I2C_ADD >> 1)
+
 class STHS34PF80
 {
     public:


### PR DESCRIPTION
Contains the following fixes:

- Arduino  begin() methods should return bools, not ints
- The Arduino begin() methods were always returning 0 - not actual status
- The Arduino header file include SFE_Bus.h, when the file is sfe_bus.h -- so doesn't work on non-windows platforms
- Make a Arduino/Qwiic I2C address macro -- for use outside of this library. 